### PR TITLE
Enable usage with Webpack 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,16 @@ node_js:
 
 env:
   matrix:
-    - ELM_VERSION=0.17.1
-    - ELM_VERSION=0.18.0
+    - ELM_VERSION=0.17.1 WEBPACK_VERSION=1.13.3
+    - ELM_VERSION=0.17.1 WEBPACK_VERSION=2.6.1
+    - ELM_VERSION=0.18.0 WEBPACK_VERSION=1.13.3
+    - ELM_VERSION=0.18.0 WEBPACK_VERSION=2.6.1
 
 before_install:
   # Don't create a lock file in order to work around:
   # https://github.com/npm/npm/issues/16987
   - npm install elm@$ELM_VERSION --no-shrinkwrap
+  - npm install webpack@$WEBPACK_VERSION --no-shrinkwrap
 
 before_script:
   - npm install -g npm-install-peers

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,12 @@ env:
     - ELM_VERSION=0.17.1
     - ELM_VERSION=0.18.0
 
-install:
-  - npm install elm@$ELM_VERSION
-  - npm install
+before_install:
+  # Don't create a lock file in order to work around:
+  # https://github.com/npm/npm/issues/16987
+  - npm install elm@$ELM_VERSION --no-shrinkwrap
+
+before_script:
   - npm install -g npm-install-peers
   - npm-install-peers
   - ./node_modules/.bin/elm-repl --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
 install:
   - npm install elm@$ELM_VERSION
   - npm install
+  - npm install -g npm-install-peers
+  - npm-install-peers
   - ./node_modules/.bin/elm-repl --version
   - cd fixtures
     && ../node_modules/.bin/elm-package install -y

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const DYNAMIC_REQUIRES_VALUES = [
 const loader = function(source, inputSourceMap) {
   this.cacheable && this.cacheable();
 
-  const config = loaderUtils.getLoaderConfig(this, "elmAssetsLoader")
+  const config = loaderUtils.getOptions(this);
   config.dynamicRequires = config.dynamicRequires || 'warn';
 
   if(!(config.hasOwnProperty('module') &&

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "webpack loader for webpackifying asset references in Elm code",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/ava"
+    "test": "WEBPACK_VERSION=$(./node_modules/.bin/webpack --version) ./node_modules/.bin/ava"
   },
   "repository": {
     "type": "git",
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "babel-core": "^6.18.2",
-    "webpack": "^2.0.0"
+    "webpack": ">=1.13.3 <3.0.0"
   },
   "devDependencies": {
     "ava": "^0.19.0",
@@ -35,7 +35,8 @@
     "elm-webpack-loader": "^3.0.6",
     "file-loader": "^0.9.0",
     "memory-fs": "^0.3.0",
-    "pify": "^2.3.0"
+    "pify": "^2.3.0",
+    "semver": "^5.3.0"
   },
   "files": [
     "LICENSE",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "webpack loader for webpackifying asset references in Elm code",
   "main": "index.js",
   "scripts": {
-    "test": "ava"
+    "test": "./node_modules/.bin/ava"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,12 @@
     "url": "https://github.com/NoRedInk/elm-assets-loader/issues"
   },
   "homepage": "https://github.com/NoRedInk/elm-assets-loader#readme",
+  "dependencies": {
+    "loader-utils": "^1.0.2"
+  },
   "peerDependencies": {
-    "babel-core": "^6.18.2"
+    "babel-core": "^6.18.2",
+    "webpack": "^2.0.0"
   },
   "devDependencies": {
     "ava": "^0.16.0",
@@ -31,8 +35,7 @@
     "elm-webpack-loader": "^3.0.6",
     "file-loader": "^0.9.0",
     "memory-fs": "^0.3.0",
-    "pify": "^2.3.0",
-    "webpack": "^1.13.3"
+    "pify": "^2.3.0"
   },
   "files": [
     "LICENSE",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "webpack": "^2.0.0"
   },
   "devDependencies": {
-    "ava": "^0.16.0",
+    "ava": "^0.19.0",
     "elm": "0.17.1 - 0.18.0",
     "elm-webpack-loader": "^3.0.6",
     "file-loader": "^0.9.0",

--- a/test.js
+++ b/test.js
@@ -17,21 +17,23 @@ const globalConfig = {
     filename: 'main.js'
   },
   resolve: {
-    root: fixturesPath,
-    extensions: ['', '.js', '.elm']
+    modules: [
+      fixturesPath
+    ],
+    extensions: ['.js', '.elm']
   },
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.elm$/,
-        loaders: [
+        use: [
           path.join(__dirname, 'index.js'),
           'elm-webpack?cwd=' + fixturesPath + '&pathToMake=' + elmMakePath
         ]
       },
       {
         test: /\.svg$/,
-        loader: 'file-loader'
+        use: 'file-loader'
       }
     ]
   },

--- a/test.js
+++ b/test.js
@@ -192,7 +192,7 @@ test('dynamicRequires: ok - be silent', async t => {
   });
   const result = await compileWithStats(config);
   t.regex(result.output, /ComplexCallAsset\(A2/);
-  t.is(result.stats.warnings.length, 0);
+  t.deepEqual(result.stats.warnings, []);
 });
 
 test('dynamicRequires: warn - just warn', async t => {

--- a/test.js
+++ b/test.js
@@ -251,7 +251,7 @@ test('fail to find module when localPath is not correctly configured', async t =
     module: 'LocalPathOverride',
     tagger: 'Asset'
   });
-  await t.throws(compile(config), /Cannot resolve module \'non_sensical.png\'/);
+  await t.throws(compile(config), /Can't resolve \'non_sensical.png\'/);
 });
 
 test('raise when localPath does not return a string', async t => {

--- a/test.js
+++ b/test.js
@@ -216,7 +216,7 @@ test('dynamicRequires: error - raise when a string concatenation is tagge', asyn
     tagger: 'ComplexCallAsset',
     dynamicRequires: 'error'
   });
-  t.throws(compile(config), /Failing hard to make sure all assets.*ComplexCallAsset/);
+  await t.throws(compile(config), /Failing hard to make sure all assets.*ComplexCallAsset/);
 });
 
 test('dynamicRequires: error - raise when a variable is tagged', async t => {
@@ -227,7 +227,7 @@ test('dynamicRequires: error - raise when a variable is tagged', async t => {
     tagger: 'VariableCallAsset',
     dynamicRequires: 'error'
   });
-  t.throws(compile(config), /Failing hard to make sure all assets.*VariableCallAsset/);
+  await t.throws(compile(config), /Failing hard to make sure all assets.*VariableCallAsset/);
 });
 
 /* localPath */
@@ -251,7 +251,7 @@ test('fail to find module when localPath is not correctly configured', async t =
     module: 'LocalPathOverride',
     tagger: 'Asset'
   });
-  t.throws(compile(config), /Cannot resolve module \'non_sensical.png\'/);
+  await t.throws(compile(config), /Cannot resolve module \'non_sensical.png\'/);
 });
 
 test('raise when localPath does not return a string', async t => {
@@ -262,7 +262,7 @@ test('raise when localPath does not return a string', async t => {
     tagger: 'Asset',
     localPath: s => 42
   });
-  t.throws(compile(config), /not a string/);
+  await t.throws(compile(config), /not a string/);
 });
 
 /* query params */
@@ -273,7 +273,7 @@ test('require module to be configured', async t => {
   }, {
     tagger: 'Asset'
   });
-  t.throws(compile(config), /configure module and tagger/);
+  await t.throws(compile(config), /configure module and tagger/);
 });
 
 test('require tagger to be configured', async t => {
@@ -282,7 +282,7 @@ test('require tagger to be configured', async t => {
   }, {
     module: 'UserProject'
   });
-  t.throws(compile(config), /configure module and tagger/);
+  await t.throws(compile(config), /configure module and tagger/);
 });
 
 test('raise when dynamicRequires is set to an unknown value', async t => {
@@ -293,5 +293,5 @@ test('raise when dynamicRequires is set to an unknown value', async t => {
     tagger: 'Asset',
     dynamicRequires: 'ignore'
   });
-  t.throws(compile(config), /Expecting dynamicRequires to be one of: error | warn | ok. You gave me: ignore/);
+  await t.throws(compile(config), /Expecting dynamicRequires to be one of: error | warn | ok. You gave me: ignore/);
 });


### PR DESCRIPTION
Using the new getOptions ensures we avoid the TypeError for loaderUtils.getLoaderConfig not being a function.