### PR TITLE
chore: update peer deps to webpack 4.x.x & @babel

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const loaderUtils = require('loader-utils');
-const babel = require('babel-core');
-const {default: generate} = require('babel-generator');
+const babel = require('@babel/core');
+const {default: generate} = require('@babel/generator');
 
 const DYNAMIC_REQUIRES_OK = Symbol.for("ok");
 const DYNAMIC_REQUIRES_WARN = Symbol.for("warn");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-assets-loader",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "webpack loader for webpackifying asset references in Elm code",
   "main": "index.js",
   "scripts": {
@@ -26,8 +26,9 @@
     "loader-utils": "^1.0.2"
   },
   "peerDependencies": {
-    "babel-core": "^6.18.2",
-    "webpack": ">=1.13.3 <3.0.0"
+    "@babel/core": "latest",
+    "@babel/generator": "latest",
+    "webpack": ">=1.13.3 <4.0.0"
   },
   "devDependencies": {
     "ava": "^0.19.0",


### PR DESCRIPTION
NOTE that updating `loader-helpers` requires a code update.

https://github.com/NoRedInk/elm-assets-loader/issues/10